### PR TITLE
updated admin_refresh_ldap() to consider LDAP

### DIFF
--- a/newauth/plugins/sync/ldap/__init__.py
+++ b/newauth/plugins/sync/ldap/__init__.py
@@ -231,8 +231,12 @@ class LDAPSync(object):
 
     def admin_refresh_ldap(self, user_id):
         user = User.query.filter_by(user_id=user_id).first()
+        ldap_user = self.get_user(user.user_id)
         if not user:
             abort(404)
+        # They're new!
+        if not ldap_user:
+            self.insert_user(current_app, ldap_user)
         self.save_user(self.get_user(user.user_id), force=True)
         flash('LDAP profile refreshed', 'success')
         return redirect(url_for('AdminView:admin_user', user_id=user_id))


### PR DESCRIPTION
Currently, it assumes the user exists without any check, meaning it cannot "fix" a missing LDAP profile.  This allows it to do so gracefully.